### PR TITLE
Create Teams notification workflow for merged PRs

### DIFF
--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -1,0 +1,32 @@
+name: Notificar a Teams sobre PR Fusionado
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify_teams:
+    # Solo se ejecuta si el Pull Request ha sido fusionado (merged)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Enviar notificación a Teams
+        # Utilizamos una Acción del Marketplace que sabe cómo enviar mensajes a Teams
+        uses: jdcargile/ms-teams-notification@v1.5 
+        with:
+          # Usamos el Secreto que creaste con la URL del Webhook
+          ms-teams-webhook-uri: ${{ secrets.MSTEAMS_WEBHOOK_URL }}
+          
+          # Este es el título que aparecerá en la notificación de Teams
+          notification-summary: ✅ ¡Código Fusionado en ${{ github.repository }}!
+          
+          # Puedes personalizar el color (verde para éxito)
+          notification-color: '28A745'
+          
+          # Cuerpo del mensaje (Markdown es aceptado)
+          notification-message: |
+            Se ha fusionado un nuevo cambio: *${{ github.event.pull_request.title }}*
+            * *Autor:* @${{ github.event.pull_request.user.login }}
+            * *Rama Target:* ${{ github.event.pull_request.base.ref }}
+            [Ver Pull Request](${{ github.event.pull_request.html_url }})


### PR DESCRIPTION
Adds a GitHub Actions workflow to notify Microsoft Teams when a pull request is merged.